### PR TITLE
[FIX] 특정 액션 수행 시 돈 거래(MoneyTransactions) 데이터가 중복 생성되는 문제

### DIFF
--- a/src/components/CategoryBoard.tsx
+++ b/src/components/CategoryBoard.tsx
@@ -23,7 +23,7 @@ import Gift3 from "@assets/icons/gift3.png";
 import useMoneyStore from '@zustand/useMoneyStore';
 import useUserStore from '@zustand/useUserStore';
 import { performCareAction } from '@/apis/cares';
-import { processTransaction } from '@/apis/users';
+import { getUserProperty } from '@/apis/users';
 import { calculateActionId } from 'utils/actionIdCalculator';
 import { getPetInfo } from '@/apis/pets';
 
@@ -132,13 +132,7 @@ export default function CategoryBoard({ category, onClose }: CategoryBoardProps)
     const price = pricesByCategory[category]?.[fallbackKey] ?? selectedItemInfo.price;
 
     try {
-      // 2. processTransaction 함수로 결제 요청
-      const transactionResult = await processTransaction({
-        amount: -price,
-        source: 'care',
-      }, userId);
-
-      // 3. performCareAction 함수로 행동 요청W
+      // performCareAction 함수로 행동 요청
       const actionIdToSend = calculateActionId(
         category,
         selectedLocalItemId,
@@ -155,12 +149,15 @@ export default function CategoryBoard({ category, onClose }: CategoryBoardProps)
         userId: userId
       });
 
+      // getUserProperty 함수로 현재 돈 조회 요청
+      const moneyGetResult = await getUserProperty(userId);
+
       // 최신 펫 정보로 전역 스토어를 업데이트합니다.
       setPetInfo(updatedPetInfo);
 
       // --- 모든 요청 성공 ---
       alert(`${actionResult.actionPerformed} 구입 완료!`);
-      setMoney(transactionResult.currentMoney); // 잔액 업데이트
+      setMoney(moneyGetResult.money); // 잔액 업데이트
       onClose();
 
     } catch (error: any) {


### PR DESCRIPTION
## 어떤 기능인가요?

원래 flow대로 했을 시에 MoneyTransactions Table에 두 개의 중복 데이터가 생성됨.
원래 flow:
  - POST `users/transcations` API 호출 (거래 기록 생성)
  - POST `cares/action` API 호출 (액션 수행 및 거래 기록 또 생성)

변경 flow:
  - POST `cares/action` API 호출 (액션 수행 및 거래 기록 생성을 서버에 위임)
  - GET `users/property` API 호출 (액션으로 인해 변경된 최종 자산 상태를 가져와 UI에 반영)

##  어떻게 구현하면 좋을까요?

클라이언트에서 직접 호출하던 POST /users/transactions API를 제거합니다.

돈 거래 기록 생성은 POST /cares/action API가 호출될 때 서버 내부에서 책임지고 처리하는 것으로 보입니다. 따라서 클라이언트는 POST /cares/action만 호출하여 액션을 실행하고, 액션이 성공적으로 완료되면 GET /users/property API를 호출하여 변경된 사용자 자산 상태를 화면에 업데이트합니다.

##  작업 TODO

- [ ] 기존 POST `/users/transactions` API 호출 코드 식별 및 제거
- [ ] POST `/cares/action` API 호출 성공 후 실행되는 로직에 GET  `/users/property` 호출 추가
- [ ] GET `/users/property` 응답 결과를 Zustand에 반영하여 UI 업데이트

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #35