### PR TITLE
[FEAT] 미니게임 결과 API 연동(`POST /api/v1/users/transactions`) 및 UI 실시간 업데이트 추가(Navbar의 money)

### DIFF
--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -62,7 +62,7 @@ export const getUserProperty = async (userId: string): Promise<UserPropertyRespo
   }
 };
 
-// 미완 
+// backend 개발 보류
 export const addUserMoney = async (userId: string, amount: number): Promise<UserPropertyResponse> => {
   try {
     const url = `${API_URL}${USER_BASE}/property/money`; // 디비에 이 사용자에게 이 정도의 골드를 제공해줘!!라고 요청하는 api

--- a/src/components/AttendanceBoard.tsx
+++ b/src/components/AttendanceBoard.tsx
@@ -7,6 +7,7 @@ import { SCREEN_WIDTH, SCREEN_HEIGHT } from '@/constants/dimensions';
 import { getAttendanceBoard, postAttendanceCheckin } from '@/apis/events';
 import type { AttendanceDay } from '@/apis/events';
 import useUserStore from '@zustand/useUserStore';
+import useMoneyStore from '@zustand/useMoneyStore';
 import { LoadingSpinner } from './LoadingSpinner';
 import axios from 'axios';
 
@@ -16,6 +17,7 @@ interface AttendanceBoardProps {
 
 export default function AttendanceBoard({ onClose }: AttendanceBoardProps) {
   const { userId } = useUserStore();
+  const addMoney = useMoneyStore(state => state.addMoney);
   const [board, setBoard] = useState<AttendanceDay[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -54,7 +56,12 @@ export default function AttendanceBoard({ onClose }: AttendanceBoardProps) {
 
     try {
       const response = await postAttendanceCheckin(userId);
-      Alert.alert('출석 완료', `${response.data.todayReward.amount} 코인을 받았어요!`);
+      const rewardAmount = response.data.todayReward.amount;
+
+      // Zustand store 업데이트 (navbar 반영)
+      addMoney(rewardAmount);
+
+      Alert.alert('출석 완료', `${rewardAmount} 코인을 받았어요!`);
       onClose();
     } catch (error: any) {
       if (axios.isAxiosError(error) && error.response) {

--- a/src/components/CategoryBoard.tsx
+++ b/src/components/CategoryBoard.tsx
@@ -61,6 +61,7 @@ export default function CategoryBoard({ category, onClose }: CategoryBoardProps)
 
   const userId = useUserStore(state => state.userId);
   const setMoney = useMoneyStore(state => state.setMoney);
+  const spendMoney = useMoneyStore(state => state.spendMoney);
 
   // 사용자가 선택한 아이템의 '로컬 ID'(1, 2, 3)를 저장할 상태 → Board 뜬 순서대로 1, 2, 3.
   const [selectedLocalItemId, setSelectedLocalItemId] = useState<number | null>(null);
@@ -156,8 +157,10 @@ export default function CategoryBoard({ category, onClose }: CategoryBoardProps)
       setPetInfo(updatedPetInfo);
 
       // --- 모든 요청 성공 ---
+      // Zustand store 업데이트 (navbar 반영)
+      spendMoney(price);
+
       alert(`${actionResult.actionPerformed} 구입 완료!`);
-      setMoney(moneyGetResult.money); // 잔액 업데이트
       onClose();
 
     } catch (error: any) {


### PR DESCRIPTION
## 어떤 기능인가요?
미니게임 결과를 `POST /api/v1/users/transactions`를 이용하여 DB에 저장합니다.

모든 돈 변경 지점(미니게임 보상, 출석 체크, 상점 구매)에서 Zustand의 `useMoneyStore`를 활용하여 navbar의 MoneyStatus가 실시간으로 업데이트되도록 하였습니다.

## 어떻게 구현하면 좋을까요?
각 머니 변경 지점에서 백엔드 API 호출 성공 후 Zustand store의 `addMoney()` 또는 `spendMoney()` 액션을 호출하여 전역 상태를 업데이트합니다.

## 작업 TODO
- [x] MinigameWrapper에서 게임 종료 시 `addMoney()` 호출 추가
- [x] AttendanceBoard에서 출석 체크 완료 시 `addMoney()` 호출 추가
- [x] CategoryBoard에서 아이템 구매 시 `spendMoney()` 호출 추가
- [x] 각 지점에서 백엔드 API 트랜잭션 처리 확인
- [x] Navbar의 MoneyStatus 실시간 반영 확인

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #39 