### PR TITLE
[FEAT] 설정 모달 추가, 앱 정보 확인 및 초기화 기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-config": "^1.0.0",
         "expo-linear-gradient": "~14.1.5",
         "expo-status-bar": "~2.2.3",
+        "expo-updates": "~29.0.12",
         "nativewind": "^4.1.23",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -27,6 +28,7 @@
         "react-native-game-engine": "^1.2.0",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-linear-gradient": "^2.8.3",
+        "react-native-restart": "^0.0.27",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-svg": "^15.11.2",
@@ -5786,6 +5788,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.7.tgz",
+      "integrity": "sha512-Q/b1X0fM+3beqqvffok14pjxMF600NxopdSr9WJY61fF4xllcVnALS0kEudffp9ihMOfcb5xWYqzKj6jMqYDIw==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.14.tgz",
@@ -5810,6 +5818,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.7.tgz",
@@ -5828,6 +5842,110 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.8.tgz",
+      "integrity": "sha512-nA5PwU2uiUd+2nkDWf9e71AuFAtbrb330g/ecvuu52bmaXtN8J8oiilc9BDvAX0gg2fbtOaZdEdjBYopt1jdlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.8",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/config": {
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.10.tgz",
+      "integrity": "sha512-lJMof5Nqakq1DxGYlghYB/ogSBjmv4Fxn1ovyDmcjlRsQdFCXgu06gEUogkhPtc9wBt9WlTTfqENln5HHyLW6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.2",
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "^10.0.7",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/config-plugins": {
+      "version": "54.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.2.tgz",
+      "integrity": "sha512-jD4qxFcURQUVsUFGMcbo63a/AnviK8WUGard+yrdQE3ZrB/aurn68SlApjirQQLEizhjI5Ar2ufqflOBlNpyPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "~10.0.7",
+        "@expo/plist": "^0.4.7",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/config-types": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
+      "license": "MIT"
+    },
+    "node_modules/expo-manifests/node_modules/@expo/json-file": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/plist": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -5881,6 +5999,68 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "29.0.12",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.12.tgz",
+      "integrity": "sha512-gE3bU6qi5g8Y1TtBzoeHac3utR0i1Wj1ufThh+zpDyFjFbegFm+gwvNLVCBagZUClYKk/4CKxh5ytnwZmPzH+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/plist": "^0.4.7",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.7",
+        "expo-manifests": "~1.0.8",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/@expo/plist": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/expo/node_modules/@expo/cli": {
       "version": "54.0.5",
@@ -10003,6 +10183,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-native-restart": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/react-native-restart/-/react-native-restart-0.0.27.tgz",
+      "integrity": "sha512-8KScVICrXwcTSJ1rjWkqVTHyEKQIttm5AIMGSK1QG1+RS5owYlE4z/1DykOTdWfVl9l16FIk0w9Xzk9ZO6jxlA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "react-native-game-engine": "^1.2.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-linear-gradient": "^2.8.3",
+    "react-native-restart": "^0.0.27",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "^15.11.2",
     "react-native-vector-icons": "^10.3.0",
     "react-native-web": "^0.21.0",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "expo-updates": "~29.0.12"
   },
   "devDependencies": {
     "@babel/core": "^7.27.7",

--- a/src/apis/endings.ts
+++ b/src/apis/endings.ts
@@ -1,0 +1,40 @@
+import axios from 'axios';
+import { API_URL } from '@config/config';
+import { ENDINGS_BASE } from '@/constants/endpoints';
+
+interface ResetGameResponse {
+  message: string;
+  status: number;
+}
+
+export const resetGame = async (userId: string): Promise<ResetGameResponse> => {
+  try {
+    console.log('게임 초기화 요청:', { userId, url: `${API_URL}${ENDINGS_BASE}/reset` });
+
+    const response = await axios.post<ResetGameResponse>(
+      `${API_URL}${ENDINGS_BASE}/reset`,
+      {},
+      {
+        headers: {
+          'user-id': userId,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    console.log('게임 초기화 성공:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      console.error('게임 초기화 API 에러:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+      });
+      const serverMessage = error.response?.data?.message || '게임 초기화에 실패했습니다.';
+      throw new Error(serverMessage);
+    }
+    console.error('게임 초기화 알 수 없는 에러:', error);
+    throw new Error('게임 초기화 실패: 알 수 없는 에러');
+  }
+};

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,207 @@
+import React, { useState } from 'react';
+import { View, Modal, StyleSheet, Alert, Text, TouchableOpacity } from 'react-native';
+import BoneLabelSvg from './BoneLabelSvg';
+import CommonButton from './CommonButton';
+import { SCREEN_WIDTH, SCREEN_HEIGHT } from '@/constants/dimensions';
+import packageJson from '../../package.json';
+import { resetGame } from '@/apis/endings';
+import useUserStore from '@zustand/useUserStore';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Updates from 'expo-updates';
+
+interface SettingsModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function SettingsModal({ visible, onClose }: SettingsModalProps) {
+  const { userId } = useUserStore();
+  const [isResetting, setIsResetting] = useState(false);
+
+  const handleReset = () => {
+    Alert.alert(
+      '초기화 확인',
+      '정말로 게임을 초기화하시겠습니까? 모든 데이터가 삭제됩니다.',
+      [
+        {
+          text: '취소',
+          style: 'cancel',
+        },
+        {
+          text: '초기화',
+          style: 'destructive',
+          onPress: async () => {
+            if (!userId) {
+              Alert.alert('오류', '사용자 정보를 찾을 수 없습니다.');
+              return;
+            }
+
+            setIsResetting(true);
+
+            try {
+              // 1. 백엔드 초기화 API 호출
+              await resetGame(userId);
+
+              // 2. AsyncStorage 초기화
+              await AsyncStorage.clear();
+
+              // 3. 앱 재시작
+              Alert.alert(
+                '초기화 완료',
+                '게임이 초기화되었습니다. 앱을 다시 시작해주세요.',
+                [
+                  {
+                    text: '확인',
+                    onPress: async () => {
+                      try {
+                        // 프로덕션 빌드에서만 작동
+                        if (!__DEV__) {
+                          await Updates.reloadAsync();
+                        } else {
+                          // 개발 모드에서는 수동 재시작 안내
+                          onClose();
+                        }
+                      } catch (e) {
+                        console.error('앱 재시작 실패:', e);
+                        onClose();
+                      }
+                    },
+                  },
+                ]
+              );
+            } catch (error: any) {
+              console.error('초기화 실패:', error);
+              Alert.alert('초기화 실패', error.message || '게임 초기화 중 오류가 발생했습니다.');
+            } finally {
+              setIsResetting(false);
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={true}
+      animationType="fade"
+      statusBarTranslucent
+      onRequestClose={onClose}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <View style={styles.innerContainer}>
+            <View style={styles.boneWrapper}>
+              <BoneLabelSvg label="설정" />
+            </View>
+
+            <View style={styles.contentContainer}>
+              <View style={styles.infoSection}>
+                <Text style={styles.infoLabel}>버전</Text>
+                <Text style={styles.infoValue}>{packageJson.version}</Text>
+              </View>
+
+              <View style={styles.infoSection}>
+                <Text style={styles.infoLabel}>개발팀</Text>
+                <Text style={styles.infoValue}>no-so-gong</Text>
+              </View>
+
+              <View style={styles.divider} />
+            </View>
+
+            <View style={styles.buttonRow}>
+              <TouchableOpacity style={styles.resetButton} onPress={handleReset}>
+                <Text style={styles.resetButtonText}>초기화</Text>
+              </TouchableOpacity>
+              <CommonButton label="닫기" onPress={onClose} />
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    backgroundColor: '#CBA74E',
+    borderRadius: SCREEN_WIDTH * 0.08,
+    padding: SCREEN_WIDTH * 0.03,
+    width: SCREEN_WIDTH * 0.88,
+    marginHorizontal: SCREEN_HEIGHT * 0.1,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+  },
+  innerContainer: {
+    backgroundColor: '#FFDD82',
+    borderRadius: SCREEN_WIDTH * 0.05,
+    padding: SCREEN_WIDTH * 0.04,
+    width: '100%',
+    alignItems: 'center',
+  },
+  boneWrapper: {
+    position: 'absolute',
+    top: -SCREEN_HEIGHT * 0.038,
+    left: SCREEN_WIDTH * 0.29,
+    zIndex: 10,
+  },
+  contentContainer: {
+    marginTop: SCREEN_HEIGHT * 0.015,
+    marginBottom: SCREEN_HEIGHT * 0.003,
+    width: '100%',
+    alignItems: 'center',
+  },
+  infoSection: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    paddingVertical: SCREEN_HEIGHT * 0.01,
+    paddingHorizontal: SCREEN_WIDTH * 0.05,
+  },
+  infoLabel: {
+    fontSize: SCREEN_WIDTH * 0.04,
+    fontWeight: 'bold',
+    color: '#8B6914',
+  },
+  infoValue: {
+    fontSize: SCREEN_WIDTH * 0.04,
+    color: '#5C4A0C',
+  },
+  divider: {
+    width: '90%',
+    height: 2,
+    backgroundColor: '#CBA74E',
+    marginVertical: SCREEN_HEIGHT * 0.015,
+  },
+  resetButton: {
+    backgroundColor: '#DC2626',
+    paddingVertical: SCREEN_HEIGHT * 0.01,
+    paddingHorizontal: SCREEN_WIDTH * 0.06,
+    marginTop: SCREEN_HEIGHT * 0.014,
+    borderRadius: 15,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+  },
+  resetButtonText: {
+    color: '#fff',
+    fontFamily: 'BagelFatOne-Regular',
+    fontSize: SCREEN_WIDTH * 0.04,
+    textAlign: 'center',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+});

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -4,3 +4,4 @@ export const USER_BASE = `${API_BASE}/users`;
 export const PET_BASE = `${API_BASE}/pets`;
 export const EVENT_BASE = `${API_BASE}/events`;
 export const CARE_BASE = `${API_BASE}/cares`;
+export const ENDINGS_BASE = `${API_BASE}/endings`;

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -6,6 +6,7 @@ import BoneLabelSvg from '@/components/BoneLabelSvg';
 import IconActionButton from '@/components/IconActionButton';
 import AttendanceBoard from '@/components/AttendanceBoard';
 import CategoryBoard from '@/components/CategoryBoard';
+import SettingsModal from '@/components/SettingsModal';
 import SVGButton from '@/components/SVGButton';
 import { useNavigation } from '@react-navigation/native';
 import { RootStackParamList } from '../types/navigationTypes';
@@ -51,6 +52,9 @@ export default function MainScreen() {
 
   // 상점 모달 상태
   const [isCategoryVisible, setIsCategoryVisible] = useState(true);
+
+  // 설정 모달 상태
+  const [isSettingsVisible, setIsSettingsVisible] = useState(false);
 
   // 현재 렌더링 중인 동물 인덱스 상태
   const [currentAnimalIndex, setCurrentAnimalIndex] = useState(0);
@@ -105,6 +109,12 @@ export default function MainScreen() {
       {isAttendanceVisible && (
         <AttendanceBoard onClose={() => setIsAttendanceVisible(false)} />
       )}
+      {isSettingsVisible && (
+        <SettingsModal
+          visible={isSettingsVisible}
+          onClose={() => setIsSettingsVisible(false)}
+        />
+      )}
       <ImageBackground
         source={require('@assets/images/Main.png')}
         style={styles.background}
@@ -134,8 +144,16 @@ export default function MainScreen() {
           </View>
         </View>
 
-        {/* 유저 버튼 및 게임 버튼 */}
+        {/* 설정 및 게임 버튼 (좌측) */}
         <View style={[styles.userGameWrapper, { zIndex: 10 }]}>
+          <SVGButton
+            iconName="cog"
+            iconSize={30}
+            iconColor="#fff"
+            backgroundColor="#CBA74E"
+            style={{ width: 50, height: 50, marginLeft: -15 }}
+            onPress={() => setIsSettingsVisible(true)}
+          />
           <SVGButton
             iconName="gamepad-variant"
             iconSize={30}
@@ -277,7 +295,7 @@ const styles = StyleSheet.create({
   },
   userGameWrapper: {
     position: 'absolute',
-    top: 140,
+    top: 110,
     left: 24,
     alignItems: 'center',
     gap: 20,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "./zustand/*"
       ],
     },
+    "resolveJsonModule": true,
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
## 어떤 기능인가요?

MainScreen에 설정 모달을 추가하여 앱 정보 확인 및 게임 초기화 기능을 제공합니다.

## 어떻게 구현하면 좋을까요?
  **1. SettingsModal 컴포넌트 생성**
  - AttendanceBoard와 동일한 디자인 스타일 적용
  - 앱 정보(버전, 개발팀) 표시
  - 게임 초기화 버튼 추가

  **2. MainScreen에 설정 버튼 추가**
  - 좌측 상단에 톱니바퀴(⚙️) 아이콘 배치
  - 게임/출석 버튼 위에 위치
  - 클릭 시 설정 모달 열기

  **3. 버전 정보 자동화**
  - `package.json`에서 버전 자동으로 읽어오기
  - `tsconfig.json`에 `resolveJsonModule: true` 설정

  ## 작업 TODO

  - [x] SettingsModal 컴포넌트 생성 (`src/components/SettingsModal.tsx`)
  - [x] MainScreen에 톱니바퀴 아이콘 추가 (좌측 상단)
  - [x] 설정 모달 열기/닫기 로직 구현
  - [x] 앱 정보 섹션 추가 (버전, 개발팀)
  - [x] 초기화 버튼 스타일링 (빨간색으로 강조)
  - [x] 초기화 확인 Alert 구현
  - [x] `package.json`에서 버전 자동 읽기
  - [x] `tsconfig.json`에 `resolveJsonModule` 설정 추가
  - [x] `POST /api/v1/endings/reset` API 연동 (다음 작업)

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #41