### PR TITLE
[FEAT] 미니게임 API 연동

### DIFF
--- a/src/apis/minigames.ts
+++ b/src/apis/minigames.ts
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import { API_URL } from '@config/config';
+import { MINIGAME_BASE } from '@/constants/endpoints';
+
+// 미니게임 시작 응답 타입
+export interface MinigameStartResponse {
+  message: string;
+  data: {
+    canPlay: boolean;
+    remainingPlays: number;
+    gameId: number;
+  };
+  status: number;
+}
+
+// 미니게임 결과 요청 타입
+export interface MinigameResultRequest {
+  score: number | null;
+  money: number | null;
+  timeSpent: number | null;
+  startedAt: string;
+  completedAt: string | null;
+}
+
+// 미니게임 결과 응답 타입
+export interface MinigameResultData {
+  startedAt: string;
+  completedAt: string | null;
+  score: number | null;
+  timeSpent: number | null;
+  money: number | null;
+  gameId: number;
+}
+
+export interface MinigameResultResponse {
+  status: number;
+  message: string;
+  data: {
+    minigameResult: MinigameResultData;
+  };
+}
+
+export const startMinigame = async (
+  gameId: number,
+  userId: string
+): Promise<MinigameStartResponse> => {
+  try {
+    const response = await axios.post<MinigameStartResponse>(
+      `${API_URL}${MINIGAME_BASE}/${gameId}/start`,
+      {},
+      {
+        headers: {
+          'user-id': userId,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const serverMessage = error.response?.data?.message || '미니게임 시작에 실패했습니다.';
+      throw new Error(serverMessage);
+    }
+    throw new Error('알 수 없는 오류로 미니게임 시작에 실패했습니다.');
+  }
+};
+
+export const submitMinigameResult = async (
+  gameId: number,
+  resultData: MinigameResultRequest,
+  userId: string
+): Promise<MinigameResultResponse> => {
+  try {
+    const response = await axios.post<MinigameResultResponse>(
+      `${API_URL}${MINIGAME_BASE}/${gameId}/result`,
+      resultData,
+      {
+        headers: {
+          'user-id': userId,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const serverMessage = error.response?.data?.message || '미니게임 결과 제출에 실패했습니다.';
+      throw new Error(serverMessage);
+    }
+    throw new Error('알 수 없는 오류로 미니게임 결과 제출에 실패했습니다.');
+  }
+};

--- a/src/components/minigames/MinigameWrapper.tsx
+++ b/src/components/minigames/MinigameWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, Modal, Text, StyleSheet, TouchableOpacity, Alert, Animated } from 'react-native';
 import { SCREEN_WIDTH, SCREEN_HEIGHT } from '@/constants/dimensions';
-import { processTransaction } from '@/apis/users';
+import { startMinigame, submitMinigameResult } from '@/apis/minigames';
 import useMoneyStore from '@zustand/useMoneyStore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -13,6 +13,7 @@ export interface MinigameProps {
 
 interface MinigameWrapperProps {
   userId: string;
+  gameId: number; // 1, 2, 3 중 하나
   gameName: string;
   goldPerPoint?: number;
   children: (props: MinigameProps) => React.ReactNode;
@@ -22,6 +23,7 @@ interface MinigameWrapperProps {
 
 export default function MinigameWrapper({
   userId,
+  gameId,
   gameName,
   goldPerPoint = 1,
   children,
@@ -32,40 +34,64 @@ export default function MinigameWrapper({
   const [totalGoldEarned, setTotalGoldEarned] = useState(0);
   const [gameEnded, setGameEnded] = useState(false);
   const [showGoldAnimation, setShowGoldAnimation] = useState(false);
+  const [gameStartTime, setGameStartTime] = useState<string | null>(null);
+  const [canPlay, setCanPlay] = useState(true);
+  const [remainingPlays, setRemainingPlays] = useState<number | null>(null);
+  const [isCheckingPlayability, setIsCheckingPlayability] = useState(false);
 
   const addMoney = useMoneyStore(state => state.addMoney);
   const goldAnimationValue = useRef(new Animated.Value(0)).current;
   const goldScaleValue = useRef(new Animated.Value(0)).current;
 
+  // 게임이 보여질 때 시작 시간 기록 (GameScreen에서 이미 체크 완료)
+  useEffect(() => {
+    if (visible && !gameEnded) {
+      setGameStartTime(new Date().toISOString());
+    }
+  }, [visible, gameEnded]);
+
   const handleGameEnd = async (score: number) => {
     const goldEarned = score * goldPerPoint;
+    const endTime = new Date().toISOString();
 
     setCurrentScore(score);
     setTotalGoldEarned(goldEarned);
-    setGameEnded(true);
+    setGameEnded(true); // 바로 결과 화면으로 전환
+
+    // 시작 시간이 없으면 현재 시간으로 설정 (fallback)
+    const startTime = gameStartTime || endTime;
+
+    // 플레이 시간 계산 (초 단위)
+    const timeSpent = Math.floor(
+      (new Date(endTime).getTime() - new Date(startTime).getTime()) / 1000
+    );
 
     try {
-      // 골드 지급 API 호출
+      // 미니게임 결과 제출 API 호출 (재화 지급 포함)
+      const response = await submitMinigameResult(
+        gameId,
+        {
+          score: score,
+          money: goldEarned,
+          timeSpent: timeSpent,
+          startedAt: startTime,
+          completedAt: endTime,
+        },
+        userId
+      );
+
+      console.log(`${gameName} 게임 종료 - 점수: ${score}, 골드: ${goldEarned} 지급 완료`);
+      console.log('API 응답:', response);
+
+      // Zustand store 업데이트 (navbar 반영)
       if (goldEarned > 0) {
-        const response = await processTransaction(
-          {
-            amount: goldEarned,
-            source: `minigame-${gameName}`,
-          },
-          userId
-        );
-
-        console.log(`${gameName} 게임 종료 - 점수: ${score}, 골드: ${goldEarned} 지급 완료`);
-
-        // Zustand store 업데이트 (navbar 반영)
         addMoney(goldEarned);
-
-        // 골드 획득 애니메이션 시작
+        // 결과 화면에서 골드 획득 애니메이션 시작
         startGoldAnimation();
       }
     } catch (error) {
-      console.error('골드 지급 실패:', error);
-      Alert.alert('알림', '골드 지급 중 오류가 발생했습니다.');
+      console.error('미니게임 결과 제출 실패:', error);
+      Alert.alert('알림', '미니게임 결과 제출 중 오류가 발생했습니다.');
     }
   };
 
@@ -75,11 +101,11 @@ export default function MinigameWrapper({
 
   const startGoldAnimation = () => {
     setShowGoldAnimation(true);
-    
+
     // 애니메이션 초기화
     goldAnimationValue.setValue(0);
     goldScaleValue.setValue(0);
-    
+
     // 동시 애니메이션 시작
     Animated.parallel([
       Animated.sequence([
@@ -111,12 +137,35 @@ export default function MinigameWrapper({
     setGameEnded(false);
     setCurrentScore(0);
     setTotalGoldEarned(0);
+    setGameStartTime(null);
+    setCanPlay(true);
+    setRemainingPlays(null);
     onClose();
   };
 
-  const handleRestart = () => {
+  const handleRestart = async () => {
     setGameEnded(false);
     setCurrentScore(0);
+    setTotalGoldEarned(0);
+    setShowGoldAnimation(false); // 골드 애니메이션 숨김
+
+    // 재시작 시 플레이 가능 여부 다시 확인
+    try {
+      const response = await startMinigame(gameId, userId);
+      setCanPlay(response.data.canPlay);
+      setRemainingPlays(response.data.remainingPlays);
+      setGameStartTime(new Date().toISOString());
+
+      if (!response.data.canPlay) {
+        Alert.alert('알림', '오늘의 플레이 횟수를 모두 사용했습니다.\n(하루 횟수: 게임당 3회)');
+        handleClose();
+      }
+    } catch (error) {
+      console.error('미니게임 재시작 실패:', error);
+      const errorMessage = error instanceof Error ? error.message : '게임을 재시작할 수 없습니다.';
+      Alert.alert('알림', `${errorMessage}\n(하루 횟수: 게임당 3회)`);
+      handleClose();
+    }
   };
 
   return (
@@ -128,7 +177,7 @@ export default function MinigameWrapper({
             <Text style={styles.gameOverText}>게임 종료!</Text>
             <Text style={styles.scoreText}>점수: {currentScore}</Text>
             <Text style={styles.goldText}>획득 골드: {totalGoldEarned}</Text>
-            
+
             <View style={styles.buttonContainer}>
               <TouchableOpacity style={styles.restartButton} onPress={handleRestart}>
                 <Text style={styles.buttonText}>다시 하기</Text>
@@ -137,17 +186,8 @@ export default function MinigameWrapper({
                 <Text style={styles.buttonText}>나가기</Text>
               </TouchableOpacity>
             </View>
-          </View>
-        ) : (
-          <>
-            {/* 게임 UI */}
-            {children({
-              userId,
-              onGameEnd: handleGameEnd,
-              onScoreUpdate: handleScoreUpdate,
-            })}
 
-            {/* 골드 획득 애니메이션 */}
+            {/* 골드 획득 애니메이션 (결과 화면 위에 표시) */}
             {showGoldAnimation && (
               <Animated.View
                 style={[
@@ -169,6 +209,15 @@ export default function MinigameWrapper({
                 <Text style={styles.goldAnimationText}>+{totalGoldEarned} 골드!</Text>
               </Animated.View>
             )}
+          </View>
+        ) : (
+          <>
+            {/* 게임 UI */}
+            {children({
+              userId,
+              onGameEnd: handleGameEnd,
+              onScoreUpdate: handleScoreUpdate,
+            })}
 
             {/* 상단 UI - 나가기 버튼 */}
             <View style={styles.topUI}>

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -5,3 +5,4 @@ export const PET_BASE = `${API_BASE}/pets`;
 export const EVENT_BASE = `${API_BASE}/events`;
 export const CARE_BASE = `${API_BASE}/cares`;
 export const ENDING_BASE = `${API_BASE}/endings`;
+export const MINIGAME_BASE = `${API_BASE}/minigames`;


### PR DESCRIPTION
## 어떤 기능인가요?

미니게임 API를 연동합니다.

##  어떻게 구현하면 좋을까요?

구현 아이디어가 있다면 적어주세요.

##  작업 TODO

- [x] 미니게임 결과 제출 `POST api/v1/minigames/{gameId}/result`
- [x] 미니게임 플레이 요청 (진입) `POST api/v1/minigames/{gameId}/start`
- [x] 미니게임 골드 지급 애니메이션 수정.
  - `다시 하기` 버튼을 누를 시에 **+0 골드** 뜨는 문제가 있었습니다. 해당 애니메이션이 `다시 하기` 버튼을 누를 시에 뜨지 않게 했으며, 추가적으로 게임 결과화면으로 넘어갈 때 애니메이션이 실행되게 하였습니다.

## 다른 방법이 있을까요?

이 기능의 다른 해결 방법이나 대체 아이디어가 있다면 알려주세요.

##  추가 정보

closes #48 
